### PR TITLE
Add axios interceptor checking for expired token

### DIFF
--- a/src/http-common.ts
+++ b/src/http-common.ts
@@ -15,7 +15,20 @@ const createHttpConfigWithoutAuthorization = (baseURL: string) => axios.create({
     }
 });
 
-export const createHttpConfig = (baseURL: string, token?: string) =>
-    (token !== undefined && token !== "")
+export const createHttpConfig = (baseURL: string, token?: string) => {
+    const axios_instance = (token !== undefined && token !== "")
         ? createHttpConfigWithAuthorization(baseURL, token)
         : createHttpConfigWithoutAuthorization(baseURL);
+
+    axios_instance.interceptors.response.use((response) => {
+        return response;
+    }, (error) => {
+        const errorStatus = error.response.status;
+
+        if (errorStatus === 401)
+            window.location.href = `${process.env.PUBLIC_URL}/logout`;
+        return Promise.reject(error);
+    });
+
+    return axios_instance;
+};


### PR DESCRIPTION
**Name:** Feature/expired JWT

✅ Minimal Testing
✅ Accurate assignees / reviewers

**Description:**
This pull request adds an Axios interceptor that check each request's response's status code and redirect to login page if the status code is 401 Unauthorized (this status code indicates that the user is not authenticated).